### PR TITLE
feat: add initial Go scaffolding

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module zkboo
+
+go 1.20

--- a/go/sha1.go
+++ b/go/sha1.go
@@ -1,0 +1,243 @@
+package zkboo
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+func getRandom32(randomness []byte, offset int) uint32 {
+	return binary.LittleEndian.Uint32(randomness[offset : offset+4])
+}
+
+func getBit(x uint32, i uint) uint32 {
+	return (x >> i) & 1
+}
+
+func setBit(x uint32, i uint, b uint32) uint32 {
+	if b&1 == 1 {
+		return x | (1 << i)
+	}
+	return x & ^(1 << i)
+}
+
+func mpcXOR(x, y [3]uint32, z *[3]uint32) {
+	z[0] = x[0] ^ y[0]
+	z[1] = x[1] ^ y[1]
+	z[2] = x[2] ^ y[2]
+}
+
+func mpcAND(x, y [3]uint32, z *[3]uint32, randomness [3][]byte, randCount *int, views *[3]View, countY *int) {
+	r := [3]uint32{
+		getRandom32(randomness[0], *randCount),
+		getRandom32(randomness[1], *randCount),
+		getRandom32(randomness[2], *randCount),
+	}
+	*randCount += 4
+	t := [3]uint32{}
+	t[0] = (x[0] & y[1]) ^ (x[1] & y[0]) ^ (x[0] & y[0]) ^ r[0] ^ r[1]
+	t[1] = (x[1] & y[2]) ^ (x[2] & y[1]) ^ (x[1] & y[1]) ^ r[1] ^ r[2]
+	t[2] = (x[2] & y[0]) ^ (x[0] & y[2]) ^ (x[2] & y[2]) ^ r[2] ^ r[0]
+	z[0] = t[0]
+	z[1] = t[1]
+	z[2] = t[2]
+	views[0].Y[*countY] = z[0]
+	views[1].Y[*countY] = z[1]
+	views[2].Y[*countY] = z[2]
+	(*countY)++
+}
+
+func mpcNEGATE(x [3]uint32, z *[3]uint32) {
+	z[0] = ^x[0]
+	z[1] = ^x[1]
+	z[2] = ^x[2]
+}
+
+func mpcADD(x, y [3]uint32, z *[3]uint32, randomness [3][]byte, randCount *int, views *[3]View, countY *int) {
+	c := [3]uint32{}
+	r := [3]uint32{
+		getRandom32(randomness[0], *randCount),
+		getRandom32(randomness[1], *randCount),
+		getRandom32(randomness[2], *randCount),
+	}
+	*randCount += 4
+	for i := uint(0); i < 31; i++ {
+		a0 := getBit(x[0]^c[0], i)
+		a1 := getBit(x[1]^c[1], i)
+		a2 := getBit(x[2]^c[2], i)
+		b0 := getBit(y[0]^c[0], i)
+		b1 := getBit(y[1]^c[1], i)
+		b2 := getBit(y[2]^c[2], i)
+		t := (a0 & b1) ^ (a1 & b0) ^ getBit(r[1], i)
+		c[0] = setBit(c[0], i+1, t^(a0&b0)^getBit(c[0], i)^getBit(r[0], i))
+		t = (a1 & b2) ^ (a2 & b1) ^ getBit(r[2], i)
+		c[1] = setBit(c[1], i+1, t^(a1&b1)^getBit(c[1], i)^getBit(r[1], i))
+		t = (a2 & b0) ^ (a0 & b2) ^ getBit(r[0], i)
+		c[2] = setBit(c[2], i+1, t^(a2&b2)^getBit(c[2], i)^getBit(r[2], i))
+	}
+	z[0] = x[0] ^ y[0] ^ c[0]
+	z[1] = x[1] ^ y[1] ^ c[1]
+	z[2] = x[2] ^ y[2] ^ c[2]
+	views[0].Y[*countY] = c[0]
+	views[1].Y[*countY] = c[1]
+	views[2].Y[*countY] = c[2]
+	(*countY)++
+}
+
+func mpcADDK(x [3]uint32, y uint32, z *[3]uint32, randomness [3][]byte, randCount *int, views *[3]View, countY *int) {
+	c := [3]uint32{}
+	r := [3]uint32{
+		getRandom32(randomness[0], *randCount),
+		getRandom32(randomness[1], *randCount),
+		getRandom32(randomness[2], *randCount),
+	}
+	*randCount += 4
+	for i := uint(0); i < 31; i++ {
+		a0 := getBit(x[0]^c[0], i)
+		a1 := getBit(x[1]^c[1], i)
+		a2 := getBit(x[2]^c[2], i)
+		b0 := getBit(y^c[0], i)
+		b1 := getBit(y^c[1], i)
+		b2 := getBit(y^c[2], i)
+		t := (a0 & b1) ^ (a1 & b0) ^ getBit(r[1], i)
+		c[0] = setBit(c[0], i+1, t^(a0&b0)^getBit(c[0], i)^getBit(r[0], i))
+		t = (a1 & b2) ^ (a2 & b1) ^ getBit(r[2], i)
+		c[1] = setBit(c[1], i+1, t^(a1&b1)^getBit(c[1], i)^getBit(r[1], i))
+		t = (a2 & b0) ^ (a0 & b2) ^ getBit(r[0], i)
+		c[2] = setBit(c[2], i+1, t^(a2&b2)^getBit(c[2], i)^getBit(r[2], i))
+	}
+	z[0] = x[0] ^ y ^ c[0]
+	z[1] = x[1] ^ y ^ c[1]
+	z[2] = x[2] ^ y ^ c[2]
+	views[0].Y[*countY] = c[0]
+	views[1].Y[*countY] = c[1]
+	views[2].Y[*countY] = c[2]
+	(*countY)++
+}
+
+func mpcRIGHTROTATE(x [3]uint32, n uint, z *[3]uint32) {
+	z[0] = rightRotate(x[0], n)
+	z[1] = rightRotate(x[1], n)
+	z[2] = rightRotate(x[2], n)
+}
+
+func mpcLEFTROTATE(x [3]uint32, n uint, z *[3]uint32) {
+	z[0] = leftRotate(x[0], n)
+	z[1] = leftRotate(x[1], n)
+	z[2] = leftRotate(x[2], n)
+}
+
+func mpcRIGHTSHIFT(x [3]uint32, n uint, z *[3]uint32) {
+	z[0] = x[0] >> n
+	z[1] = x[1] >> n
+	z[2] = x[2] >> n
+}
+
+func mpcMAJ(a, b, c [3]uint32, z *[3]uint32, randomness [3][]byte, randCount *int, views *[3]View, countY *int) {
+	var t0, t1 [3]uint32
+	mpcXOR(a, b, &t0)
+	mpcXOR(a, c, &t1)
+	mpcAND(t0, t1, z, randomness, randCount, views, countY)
+	mpcXOR(*z, a, z)
+}
+
+func mpcCH(e, f, g [3]uint32, z *[3]uint32, randomness [3][]byte, randCount *int, views *[3]View, countY *int) {
+	var t0 [3]uint32
+	mpcXOR(f, g, &t0)
+	mpcAND(e, t0, &t0, randomness, randCount, views, countY)
+	mpcXOR(t0, g, z)
+}
+
+func mpcSHA1(inputs [3][]byte, numBits int, randomness [3][]byte, views *[3]View) ([3][20]byte, error) {
+	if numBits > 447 {
+		return [3][20]byte{}, fmt.Errorf("input too long")
+	}
+	randCount := 0
+	countY := 0
+	chars := numBits >> 3
+	var chunks [3][64]byte
+	var w [80][3]uint32
+	for i := 0; i < 3; i++ {
+		copy(chunks[i][:], inputs[i][:chars])
+		chunks[i][chars] = 0x80
+		chunks[i][62] = byte(numBits >> 8)
+		chunks[i][63] = byte(numBits)
+		copy(views[i].X[:], chunks[i][:])
+		for j := 0; j < 16; j++ {
+			w[j][i] = uint32(chunks[i][j*4])<<24 | uint32(chunks[i][j*4+1])<<16 | uint32(chunks[i][j*4+2])<<8 | uint32(chunks[i][j*4+3])
+		}
+	}
+	var temp, t0 [3]uint32
+	for j := 16; j < 80; j++ {
+		mpcXOR(w[j-3], w[j-8], &temp)
+		mpcXOR(temp, w[j-14], &temp)
+		mpcXOR(temp, w[j-16], &temp)
+		mpcLEFTROTATE(temp, 1, &w[j])
+	}
+	a := [3]uint32{hA[0], hA[0], hA[0]}
+	b := [3]uint32{hA[1], hA[1], hA[1]}
+	c := [3]uint32{hA[2], hA[2], hA[2]}
+	d := [3]uint32{hA[3], hA[3], hA[3]}
+	e := [3]uint32{hA[4], hA[4], hA[4]}
+	var f [3]uint32
+	var k uint32
+	for i := 0; i < 80; i++ {
+		if i <= 19 {
+			mpcXOR(c, d, &f)
+			mpcAND(b, f, &f, randomness, &randCount, views, &countY)
+			mpcXOR(d, f, &f)
+			k = 0x5A827999
+		} else if i <= 39 {
+			mpcXOR(b, c, &f)
+			mpcXOR(d, f, &f)
+			k = 0x6ED9EBA1
+		} else if i <= 59 {
+			mpcMAJ(b, c, d, &f, randomness, &randCount, views, &countY)
+			k = 0x8F1BBCDC
+		} else {
+			mpcXOR(b, c, &f)
+			mpcXOR(d, f, &f)
+			k = 0xCA62C1D6
+		}
+		mpcLEFTROTATE(a, 5, &temp)
+		mpcADD(f, temp, &temp, randomness, &randCount, views, &countY)
+		mpcADD(e, temp, &temp, randomness, &randCount, views, &countY)
+		mpcADDK(temp, k, &temp, randomness, &randCount, views, &countY)
+		mpcADD(w[i], temp, &temp, randomness, &randCount, views, &countY)
+		e = d
+		d = c
+		mpcLEFTROTATE(b, 30, &c)
+		b = a
+		a = temp
+	}
+	hHa := [5][3]uint32{
+		{hA[0], hA[0], hA[0]},
+		{hA[1], hA[1], hA[1]},
+		{hA[2], hA[2], hA[2]},
+		{hA[3], hA[3], hA[3]},
+		{hA[4], hA[4], hA[4]},
+	}
+	mpcADD(hHa[0], a, &hHa[0], randomness, &randCount, views, &countY)
+	mpcADD(hHa[1], b, &hHa[1], randomness, &randCount, views, &countY)
+	mpcADD(hHa[2], c, &hHa[2], randomness, &randCount, views, &countY)
+	mpcADD(hHa[3], d, &hHa[3], randomness, &randCount, views, &countY)
+	mpcADD(hHa[4], e, &hHa[4], randomness, &randCount, views, &countY)
+	var results [3][20]byte
+	for i := 0; i < 5; i++ {
+		mpcRIGHTSHIFT(hHa[i], 24, &t0)
+		results[0][i*4] = byte(t0[0])
+		results[1][i*4] = byte(t0[1])
+		results[2][i*4] = byte(t0[2])
+		mpcRIGHTSHIFT(hHa[i], 16, &t0)
+		results[0][i*4+1] = byte(t0[0])
+		results[1][i*4+1] = byte(t0[1])
+		results[2][i*4+1] = byte(t0[2])
+		mpcRIGHTSHIFT(hHa[i], 8, &t0)
+		results[0][i*4+2] = byte(t0[0])
+		results[1][i*4+2] = byte(t0[1])
+		results[2][i*4+2] = byte(t0[2])
+		results[0][i*4+3] = byte(hHa[i][0])
+		results[1][i*4+3] = byte(hHa[i][1])
+		results[2][i*4+3] = byte(hHa[i][2])
+	}
+	return results, nil
+}

--- a/go/sha1_verify.go
+++ b/go/sha1_verify.go
@@ -1,0 +1,233 @@
+package zkboo
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+func computeH(k [16]byte, v View, r [4]byte, yLen int) [32]byte {
+	h := sha256.New()
+	h.Write(k[:])
+	h.Write(v.X[:])
+	var buf [4]byte
+	for i := 0; i < yLen; i++ {
+		binary.LittleEndian.PutUint32(buf[:], v.Y[i])
+		h.Write(buf[:])
+	}
+	h.Write(r[:])
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func outputSHA1(v View) [5]uint32 {
+	var res [5]uint32
+	copy(res[:], v.Y[YSizeSHA1-5:YSizeSHA1])
+	return res
+}
+
+func mpcXOR2(x, y [2]uint32, z *[2]uint32) {
+	z[0] = x[0] ^ y[0]
+	z[1] = x[1] ^ y[1]
+}
+
+func mpcLEFTROTATE2(x [2]uint32, n uint, z *[2]uint32) {
+	z[0] = leftRotate(x[0], n)
+	z[1] = leftRotate(x[1], n)
+}
+
+func mpcRIGHTROTATE2(x [2]uint32, n uint, z *[2]uint32) {
+	z[0] = rightRotate(x[0], n)
+	z[1] = rightRotate(x[1], n)
+}
+
+func mpcRIGHTSHIFT2(x [2]uint32, n uint, z *[2]uint32) {
+	z[0] = x[0] >> n
+	z[1] = x[1] >> n
+}
+
+func mpcANDVerify(x, y [2]uint32, z *[2]uint32, ve, ve1 View, randomness [2][]byte, randCount, countY *int) bool {
+	r := [2]uint32{
+		getRandom32(randomness[0], *randCount),
+		getRandom32(randomness[1], *randCount),
+	}
+	*randCount += 4
+	t := (x[0] & y[1]) ^ (x[1] & y[0]) ^ (x[0] & y[0]) ^ r[0] ^ r[1]
+	if ve.Y[*countY] != t {
+		return false
+	}
+	z[0] = t
+	z[1] = ve1.Y[*countY]
+	*countY++
+	return true
+}
+
+func mpcADDVerify(x, y [2]uint32, z *[2]uint32, ve, ve1 View, randomness [2][]byte, randCount, countY *int) bool {
+	r := [2]uint32{
+		getRandom32(randomness[0], *randCount),
+		getRandom32(randomness[1], *randCount),
+	}
+	*randCount += 4
+	for i := uint(0); i < 31; i++ {
+		a0 := getBit(x[0]^ve.Y[*countY], i)
+		a1 := getBit(x[1]^ve1.Y[*countY], i)
+		b0 := getBit(y[0]^ve.Y[*countY], i)
+		b1 := getBit(y[1]^ve1.Y[*countY], i)
+		t := (a0 & b1) ^ (a1 & b0) ^ getBit(r[1], i)
+		if getBit(ve.Y[*countY], i+1) != t^(a0&b0)^getBit(ve.Y[*countY], i)^getBit(r[0], i) {
+			return false
+		}
+	}
+	z[0] = x[0] ^ y[0] ^ ve.Y[*countY]
+	z[1] = x[1] ^ y[1] ^ ve1.Y[*countY]
+	*countY++
+	return true
+}
+
+func mpcMAJVerify(a, b, c [2]uint32, z *[2]uint32, ve, ve1 View, randomness [2][]byte, randCount, countY *int) bool {
+	var t0, t1 [2]uint32
+	mpcXOR2(a, b, &t0)
+	mpcXOR2(a, c, &t1)
+	if !mpcANDVerify(t0, t1, z, ve, ve1, randomness, randCount, countY) {
+		return false
+	}
+	mpcXOR2(*z, a, z)
+	return true
+}
+
+func mpcCHVerify(e, f, g [2]uint32, z *[2]uint32, ve, ve1 View, randomness [2][]byte, randCount, countY *int) bool {
+	var t0 [2]uint32
+	mpcXOR2(f, g, &t0)
+	if !mpcANDVerify(e, t0, &t0, ve, ve1, randomness, randCount, countY) {
+		return false
+	}
+	mpcXOR2(t0, g, z)
+	return true
+}
+
+func verifySHA1(a A, e int, z Z) bool {
+	hash := computeH(z.Ke, z.Ve, z.Re, YSizeSHA1)
+	if a.H[e] != hash {
+		return false
+	}
+	hash = computeH(z.Ke1, z.Ve1, z.Re1, YSizeSHA1)
+	if a.H[(e+1)%3] != hash {
+		return false
+	}
+
+	res := outputSHA1(z.Ve)
+	for i := 0; i < 5; i++ {
+		if a.Yp[e][i] != res[i] {
+			return false
+		}
+	}
+	res = outputSHA1(z.Ve1)
+	for i := 0; i < 5; i++ {
+		if a.Yp[(e+1)%3][i] != res[i] {
+			return false
+		}
+	}
+
+	var rand0 [RandomnessSizeSHA1]byte
+	if err := getAllRandomness(z.Ke, rand0[:]); err != nil {
+		return false
+	}
+	var rand1 [RandomnessSizeSHA1]byte
+	if err := getAllRandomness(z.Ke1, rand1[:]); err != nil {
+		return false
+	}
+	randomness := [2][]byte{rand0[:], rand1[:]}
+	randCount := 0
+	countY := 0
+
+	var w [80][2]uint32
+	for j := 0; j < 16; j++ {
+		w[j][0] = uint32(z.Ve.X[j*4])<<24 | uint32(z.Ve.X[j*4+1])<<16 | uint32(z.Ve.X[j*4+2])<<8 | uint32(z.Ve.X[j*4+3])
+		w[j][1] = uint32(z.Ve1.X[j*4])<<24 | uint32(z.Ve1.X[j*4+1])<<16 | uint32(z.Ve1.X[j*4+2])<<8 | uint32(z.Ve1.X[j*4+3])
+	}
+	var temp [2]uint32
+	for j := 16; j < 80; j++ {
+		mpcXOR2(w[j-3], w[j-8], &temp)
+		mpcXOR2(temp, w[j-14], &temp)
+		mpcXOR2(temp, w[j-16], &temp)
+		mpcLEFTROTATE2(temp, 1, &w[j])
+	}
+
+	va := [2]uint32{hA[0], hA[0]}
+	vb := [2]uint32{hA[1], hA[1]}
+	vc := [2]uint32{hA[2], hA[2]}
+	vd := [2]uint32{hA[3], hA[3]}
+	ve2 := [2]uint32{hA[4], hA[4]}
+	var f [2]uint32
+	var k uint32
+	var temp1 [2]uint32
+
+	for i := 0; i < 80; i++ {
+		if i <= 19 {
+			mpcXOR2(vc, vd, &f)
+			if !mpcANDVerify(vb, f, &f, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+				return false
+			}
+			mpcXOR2(vd, f, &f)
+			k = 0x5A827999
+		} else if i <= 39 {
+			mpcXOR2(vb, vc, &f)
+			mpcXOR2(vd, f, &f)
+			k = 0x6ED9EBA1
+		} else if i <= 59 {
+			if !mpcMAJVerify(vb, vc, vd, &f, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+				return false
+			}
+			k = 0x8F1BBCDC
+		} else {
+			mpcXOR2(vb, vc, &f)
+			mpcXOR2(vd, f, &f)
+			k = 0xCA62C1D6
+		}
+
+		mpcLEFTROTATE2(va, 5, &temp)
+		if !mpcADDVerify(f, temp, &temp, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(ve2, temp, &temp, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		temp1[0], temp1[1] = k, k
+		if !mpcADDVerify(temp, temp1, &temp, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(w[i], temp, &temp, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		ve2 = vd
+		vd = vc
+		mpcLEFTROTATE2(vb, 30, &vc)
+		vb = va
+		va = temp
+	}
+
+	hHa := [5][2]uint32{
+		{hA[0], hA[0]},
+		{hA[1], hA[1]},
+		{hA[2], hA[2]},
+		{hA[3], hA[3]},
+		{hA[4], hA[4]},
+	}
+	if !mpcADDVerify(hHa[0], va, &hHa[0], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[1], vb, &hHa[1], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[2], vc, &hHa[2], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[3], vd, &hHa[3], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[4], ve2, &hHa[4], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+
+	return true
+}

--- a/go/sha256.go
+++ b/go/sha256.go
@@ -1,0 +1,120 @@
+package zkboo
+
+import "fmt"
+
+func mpcSHA256(inputs [3][]byte, numBits int, randomness [3][]byte, views *[3]View) ([3][32]byte, error) {
+	if numBits > 447 {
+		return [3][32]byte{}, fmt.Errorf("input too long")
+	}
+	randCount := 0
+	countY := 0
+	chars := numBits >> 3
+	var chunks [3][64]byte
+	var w [64][3]uint32
+	for i := 0; i < 3; i++ {
+		copy(chunks[i][:], inputs[i][:chars])
+		chunks[i][chars] = 0x80
+		chunks[i][62] = byte(numBits >> 8)
+		chunks[i][63] = byte(numBits)
+		copy(views[i].X[:], chunks[i][:])
+		for j := 0; j < 16; j++ {
+			w[j][i] = uint32(chunks[i][j*4])<<24 | uint32(chunks[i][j*4+1])<<16 |
+				uint32(chunks[i][j*4+2])<<8 | uint32(chunks[i][j*4+3])
+		}
+	}
+	var s0, s1, t0, t1 [3]uint32
+	for j := 16; j < 64; j++ {
+		mpcRIGHTROTATE(w[j-15], 7, &t0)
+		mpcRIGHTROTATE(w[j-15], 18, &t1)
+		mpcXOR(t0, t1, &t0)
+		mpcRIGHTSHIFT(w[j-15], 3, &t1)
+		mpcXOR(t0, t1, &s0)
+
+		mpcRIGHTROTATE(w[j-2], 17, &t0)
+		mpcRIGHTROTATE(w[j-2], 19, &t1)
+		mpcXOR(t0, t1, &t0)
+		mpcRIGHTSHIFT(w[j-2], 10, &t1)
+		mpcXOR(t0, t1, &s1)
+
+		mpcADD(w[j-16], s0, &t1, randomness, &randCount, views, &countY)
+		mpcADD(w[j-7], t1, &t1, randomness, &randCount, views, &countY)
+		mpcADD(t1, s1, &w[j], randomness, &randCount, views, &countY)
+	}
+	a := [3]uint32{h256[0], h256[0], h256[0]}
+	b := [3]uint32{h256[1], h256[1], h256[1]}
+	c := [3]uint32{h256[2], h256[2], h256[2]}
+	d := [3]uint32{h256[3], h256[3], h256[3]}
+	e := [3]uint32{h256[4], h256[4], h256[4]}
+	f := [3]uint32{h256[5], h256[5], h256[5]}
+	g := [3]uint32{h256[6], h256[6], h256[6]}
+	h := [3]uint32{h256[7], h256[7], h256[7]}
+	var temp1, temp2, maj [3]uint32
+	for i := 0; i < 64; i++ {
+		mpcRIGHTROTATE(e, 6, &t0)
+		mpcRIGHTROTATE(e, 11, &t1)
+		mpcXOR(t0, t1, &t0)
+		mpcRIGHTROTATE(e, 25, &t1)
+		mpcXOR(t0, t1, &s1)
+
+		mpcADD(h, s1, &t0, randomness, &randCount, views, &countY)
+		mpcCH(e, f, g, &t1, randomness, &randCount, views, &countY)
+		mpcADD(t0, t1, &t1, randomness, &randCount, views, &countY)
+		mpcADDK(t1, k[i], &t1, randomness, &randCount, views, &countY)
+		mpcADD(t1, w[i], &temp1, randomness, &randCount, views, &countY)
+
+		mpcRIGHTROTATE(a, 2, &t0)
+		mpcRIGHTROTATE(a, 13, &t1)
+		mpcXOR(t0, t1, &t0)
+		mpcRIGHTROTATE(a, 22, &t1)
+		mpcXOR(t0, t1, &s0)
+
+		mpcMAJ(a, b, c, &maj, randomness, &randCount, views, &countY)
+		mpcADD(s0, maj, &temp2, randomness, &randCount, views, &countY)
+
+		h = g
+		g = f
+		f = e
+		mpcADD(d, temp1, &e, randomness, &randCount, views, &countY)
+		d = c
+		c = b
+		b = a
+		mpcADD(temp1, temp2, &a, randomness, &randCount, views, &countY)
+	}
+	hHa := [8][3]uint32{
+		{h256[0], h256[0], h256[0]},
+		{h256[1], h256[1], h256[1]},
+		{h256[2], h256[2], h256[2]},
+		{h256[3], h256[3], h256[3]},
+		{h256[4], h256[4], h256[4]},
+		{h256[5], h256[5], h256[5]},
+		{h256[6], h256[6], h256[6]},
+		{h256[7], h256[7], h256[7]},
+	}
+	mpcADD(hHa[0], a, &hHa[0], randomness, &randCount, views, &countY)
+	mpcADD(hHa[1], b, &hHa[1], randomness, &randCount, views, &countY)
+	mpcADD(hHa[2], c, &hHa[2], randomness, &randCount, views, &countY)
+	mpcADD(hHa[3], d, &hHa[3], randomness, &randCount, views, &countY)
+	mpcADD(hHa[4], e, &hHa[4], randomness, &randCount, views, &countY)
+	mpcADD(hHa[5], f, &hHa[5], randomness, &randCount, views, &countY)
+	mpcADD(hHa[6], g, &hHa[6], randomness, &randCount, views, &countY)
+	mpcADD(hHa[7], h, &hHa[7], randomness, &randCount, views, &countY)
+	var results [3][32]byte
+	for i := 0; i < 8; i++ {
+		mpcRIGHTSHIFT(hHa[i], 24, &t0)
+		results[0][i*4] = byte(t0[0])
+		results[1][i*4] = byte(t0[1])
+		results[2][i*4] = byte(t0[2])
+		mpcRIGHTSHIFT(hHa[i], 16, &t0)
+		results[0][i*4+1] = byte(t0[0])
+		results[1][i*4+1] = byte(t0[1])
+		results[2][i*4+1] = byte(t0[2])
+		mpcRIGHTSHIFT(hHa[i], 8, &t0)
+		results[0][i*4+2] = byte(t0[0])
+		results[1][i*4+2] = byte(t0[1])
+		results[2][i*4+2] = byte(t0[2])
+		results[0][i*4+3] = byte(hHa[i][0])
+		results[1][i*4+3] = byte(hHa[i][1])
+		results[2][i*4+3] = byte(hHa[i][2])
+	}
+	return results, nil
+}

--- a/go/sha256_verify.go
+++ b/go/sha256_verify.go
@@ -1,0 +1,164 @@
+package zkboo
+
+func outputSHA256(v View) [8]uint32 {
+	var res [8]uint32
+	copy(res[:], v.Y[YSizeSHA256-8:YSizeSHA256])
+	return res
+}
+
+func verifySHA256(a A, e int, z Z) bool {
+	hash := computeH(z.Ke, z.Ve, z.Re, YSizeSHA256)
+	if a.H[e] != hash {
+		return false
+	}
+	hash = computeH(z.Ke1, z.Ve1, z.Re1, YSizeSHA256)
+	if a.H[(e+1)%3] != hash {
+		return false
+	}
+	res := outputSHA256(z.Ve)
+	for i := 0; i < 8; i++ {
+		if a.Yp[e][i] != res[i] {
+			return false
+		}
+	}
+	res = outputSHA256(z.Ve1)
+	for i := 0; i < 8; i++ {
+		if a.Yp[(e+1)%3][i] != res[i] {
+			return false
+		}
+	}
+	var rand0 [RandomnessSizeSHA256]byte
+	if err := getAllRandomness(z.Ke, rand0[:]); err != nil {
+		return false
+	}
+	var rand1 [RandomnessSizeSHA256]byte
+	if err := getAllRandomness(z.Ke1, rand1[:]); err != nil {
+		return false
+	}
+	randomness := [2][]byte{rand0[:], rand1[:]}
+	randCount := 0
+	countY := 0
+	var w [64][2]uint32
+	for j := 0; j < 16; j++ {
+		w[j][0] = uint32(z.Ve.X[j*4])<<24 | uint32(z.Ve.X[j*4+1])<<16 | uint32(z.Ve.X[j*4+2])<<8 | uint32(z.Ve.X[j*4+3])
+		w[j][1] = uint32(z.Ve1.X[j*4])<<24 | uint32(z.Ve1.X[j*4+1])<<16 | uint32(z.Ve1.X[j*4+2])<<8 | uint32(z.Ve1.X[j*4+3])
+	}
+	var s0, s1, t0, t1 [2]uint32
+	for j := 16; j < 64; j++ {
+		mpcRIGHTROTATE2(w[j-15], 7, &t0)
+		mpcRIGHTROTATE2(w[j-15], 18, &t1)
+		mpcXOR2(t0, t1, &t0)
+		mpcRIGHTSHIFT2(w[j-15], 3, &t1)
+		mpcXOR2(t0, t1, &s0)
+
+		mpcRIGHTROTATE2(w[j-2], 17, &t0)
+		mpcRIGHTROTATE2(w[j-2], 19, &t1)
+		mpcXOR2(t0, t1, &t0)
+		mpcRIGHTSHIFT2(w[j-2], 10, &t1)
+		mpcXOR2(t0, t1, &s1)
+
+		if !mpcADDVerify(w[j-16], s0, &t1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(w[j-7], t1, &t1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(t1, s1, &w[j], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+	}
+	va := [2]uint32{h256[0], h256[0]}
+	vb := [2]uint32{h256[1], h256[1]}
+	vc := [2]uint32{h256[2], h256[2]}
+	vd := [2]uint32{h256[3], h256[3]}
+	ve2 := [2]uint32{h256[4], h256[4]}
+	vf := [2]uint32{h256[5], h256[5]}
+	vg := [2]uint32{h256[6], h256[6]}
+	vh := [2]uint32{h256[7], h256[7]}
+	var temp1, temp2, maj [2]uint32
+	for i := 0; i < 64; i++ {
+		mpcRIGHTROTATE2(ve2, 6, &t0)
+		mpcRIGHTROTATE2(ve2, 11, &t1)
+		mpcXOR2(t0, t1, &t0)
+		mpcRIGHTROTATE2(ve2, 25, &t1)
+		mpcXOR2(t0, t1, &s1)
+
+		if !mpcADDVerify(vh, s1, &t0, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcCHVerify(ve2, vf, vg, &t1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(t0, t1, &t1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		kConst := [2]uint32{k[i], k[i]}
+		if !mpcADDVerify(t1, kConst, &t1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(t1, w[i], &temp1, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+
+		mpcRIGHTROTATE2(va, 2, &t0)
+		mpcRIGHTROTATE2(va, 13, &t1)
+		mpcXOR2(t0, t1, &t0)
+		mpcRIGHTROTATE2(va, 22, &t1)
+		mpcXOR2(t0, t1, &s0)
+
+		if !mpcMAJVerify(va, vb, vc, &maj, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		if !mpcADDVerify(s0, maj, &temp2, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+
+		vh = vg
+		vg = vf
+		vf = ve2
+		if !mpcADDVerify(vd, temp1, &ve2, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+		vd = vc
+		vc = vb
+		vb = va
+		if !mpcADDVerify(temp1, temp2, &va, z.Ve, z.Ve1, randomness, &randCount, &countY) {
+			return false
+		}
+	}
+	hHa := [8][2]uint32{
+		{h256[0], h256[0]},
+		{h256[1], h256[1]},
+		{h256[2], h256[2]},
+		{h256[3], h256[3]},
+		{h256[4], h256[4]},
+		{h256[5], h256[5]},
+		{h256[6], h256[6]},
+		{h256[7], h256[7]},
+	}
+	if !mpcADDVerify(hHa[0], va, &hHa[0], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[1], vb, &hHa[1], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[2], vc, &hHa[2], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[3], vd, &hHa[3], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[4], ve2, &hHa[4], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[5], vf, &hHa[5], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[6], vg, &hHa[6], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	if !mpcADDVerify(hHa[7], vh, &hHa[7], z.Ve, z.Ve1, randomness, &randCount, &countY) {
+		return false
+	}
+	return true
+}

--- a/go/shared.go
+++ b/go/shared.go
@@ -1,0 +1,73 @@
+package zkboo
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+)
+
+const (
+	NumRounds            = 136
+	YSizeSHA1            = 370
+	YSizeSHA256          = 736
+	RandomnessSizeSHA1   = 1472
+	RandomnessSizeSHA256 = 2912
+)
+
+var hA = [5]uint32{0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0}
+
+var h256 = [8]uint32{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19}
+
+var k = [64]uint32{
+	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+	0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98,
+	0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+	0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6,
+	0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3,
+	0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138,
+	0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e,
+	0x92722c85, 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+	0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+	0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+	0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814,
+	0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+}
+
+type View struct {
+	X [64]byte
+	Y [YSizeSHA256]uint32
+}
+
+type A struct {
+	Yp [3][8]uint32
+	H  [3][32]byte
+}
+
+type Z struct {
+	Ke  [16]byte
+	Ke1 [16]byte
+	Ve  View
+	Ve1 View
+	Re  [4]byte
+	Re1 [4]byte
+}
+
+func rightRotate(x uint32, n uint) uint32 {
+	return (x >> n) | (x << (32 - n))
+}
+
+func leftRotate(x uint32, n uint) uint32 {
+	return (x << n) | (x >> (32 - n))
+}
+
+func getAllRandomness(key [16]byte, out []byte) error {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return err
+	}
+	iv := []byte("0123456789012345")
+	stream := cipher.NewCTR(block, iv)
+	zero := make([]byte, len(out))
+	stream.XORKeyStream(out, zero)
+	return nil
+}

--- a/solidity/SHA256Verifier.sol
+++ b/solidity/SHA256Verifier.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract SHA256Verifier {
+    uint constant Y_SIZE = 736;
+    uint constant RANDOMNESS_SIZE = 2912;
+
+    uint32[8] constant H_INIT = [
+        uint32(0x6a09e667),
+        uint32(0xbb67ae85),
+        uint32(0x3c6ef372),
+        uint32(0xa54ff53a),
+        uint32(0x510e527f),
+        uint32(0x9b05688c),
+        uint32(0x1f83d9ab),
+        uint32(0x5be0cd19)
+    ];
+
+    uint32[64] constant K = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98,
+        0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6,
+        0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3,
+        0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138,
+        0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e,
+        0x92722c85, 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+        0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814,
+        0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    ];
+
+    struct View {
+        uint8[64] X;
+        uint32[Y_SIZE] Y;
+    }
+
+    struct A {
+        uint32[8][3] Yp;
+        bytes32[3] H;
+    }
+
+    struct Z {
+        bytes16 Ke;
+        bytes16 Ke1;
+        View Ve;
+        View Ve1;
+        bytes4 Re;
+        bytes4 Re1;
+    }
+
+    function rightRotate(uint32 x, uint n) internal pure returns (uint32) {
+        return (x >> n) | (x << (32 - n));
+    }
+
+    function mpcXOR2(uint32[2] memory x, uint32[2] memory y) internal pure returns (uint32[2] memory z) {
+        z[0] = x[0] ^ y[0];
+        z[1] = x[1] ^ y[1];
+    }
+
+    function mpcRIGHTROTATE2(uint32[2] memory x, uint n) internal pure returns (uint32[2] memory z) {
+        z[0] = rightRotate(x[0], n);
+        z[1] = rightRotate(x[1], n);
+    }
+
+    function mpcRIGHTSHIFT2(uint32[2] memory x, uint n) internal pure returns (uint32[2] memory z) {
+        z[0] = x[0] >> n;
+        z[1] = x[1] >> n;
+    }
+
+    function getRandom32(bytes memory randomness, uint offset) internal pure returns (uint32) {
+        return uint32(uint8(randomness[offset])) |
+            (uint32(uint8(randomness[offset + 1])) << 8) |
+            (uint32(uint8(randomness[offset + 2])) << 16) |
+            (uint32(uint8(randomness[offset + 3])) << 24);
+    }
+
+    function getBit(uint32 x, uint i) internal pure returns (uint32) {
+        return (x >> i) & 1;
+    }
+
+    function computeH(bytes16 k, View memory v, bytes4 r) internal pure returns (bytes32) {
+        bytes memory data = new bytes(16 + 64 + 4 * Y_SIZE + 4);
+        uint ptr = 0;
+        for (uint i = 0; i < 16; i++) data[ptr++] = k[i];
+        for (uint i = 0; i < 64; i++) data[ptr++] = bytes1(v.X[i]);
+        for (uint i = 0; i < Y_SIZE; i++) {
+            uint32 y = v.Y[i];
+            data[ptr++] = bytes1(uint8(y));
+            data[ptr++] = bytes1(uint8(y >> 8));
+            data[ptr++] = bytes1(uint8(y >> 16));
+            data[ptr++] = bytes1(uint8(y >> 24));
+        }
+        for (uint i = 0; i < 4; i++) data[ptr++] = r[i];
+        return sha256(data);
+    }
+
+    function outputSHA256(View memory v) internal pure returns (uint32[8] memory res) {
+        for (uint i = 0; i < 8; i++) {
+            res[i] = v.Y[Y_SIZE - 8 + i];
+        }
+    }
+
+    function getAllRandomness(bytes16 key) internal pure returns (bytes memory out) {
+        out = new bytes(RANDOMNESS_SIZE);
+        uint offset = 0;
+        uint counter = 0;
+        while (offset < RANDOMNESS_SIZE) {
+            bytes32 block = sha256(abi.encodePacked(key, counter));
+            for (uint i = 0; i < 32 && offset < RANDOMNESS_SIZE; i++) {
+                out[offset++] = block[i];
+            }
+            counter++;
+        }
+    }
+
+    function mpcANDVerify(
+        uint32[2] memory x,
+        uint32[2] memory y,
+        View memory ve,
+        View memory ve1,
+        bytes memory rand0,
+        bytes memory rand1,
+        uint randCount,
+        uint countY
+    ) internal pure returns (bool, uint32[2] memory, uint, uint) {
+        uint32 r0 = getRandom32(rand0, randCount);
+        uint32 r1 = getRandom32(rand1, randCount);
+        randCount += 4;
+        uint32 t = (x[0] & y[1]) ^ (x[1] & y[0]) ^ (x[0] & y[0]) ^ r0 ^ r1;
+        if (ve.Y[countY] != t) {
+            return (false, x, randCount, countY);
+        }
+        uint32[2] memory z;
+        z[0] = t;
+        z[1] = ve1.Y[countY];
+        countY += 1;
+        return (true, z, randCount, countY);
+    }
+
+    function mpcADDVerify(
+        uint32[2] memory x,
+        uint32[2] memory y,
+        View memory ve,
+        View memory ve1,
+        bytes memory rand0,
+        bytes memory rand1,
+        uint randCount,
+        uint countY
+    ) internal pure returns (bool, uint32[2] memory, uint, uint) {
+        uint32 r0 = getRandom32(rand0, randCount);
+        uint32 r1 = getRandom32(rand1, randCount);
+        randCount += 4;
+        for (uint i = 0; i < 31; i++) {
+            uint32 a0 = getBit(x[0] ^ ve.Y[countY], i);
+            uint32 a1 = getBit(x[1] ^ ve1.Y[countY], i);
+            uint32 b0 = getBit(y[0] ^ ve.Y[countY], i);
+            uint32 b1 = getBit(y[1] ^ ve1.Y[countY], i);
+            uint32 t = (a0 & b1) ^ (a1 & b0) ^ getBit(r1, i);
+            if (getBit(ve.Y[countY], i + 1) != (t ^ (a0 & b0) ^ getBit(ve.Y[countY], i) ^ getBit(r0, i))) {
+                return (false, x, randCount, countY);
+            }
+        }
+        uint32[2] memory z;
+        z[0] = x[0] ^ y[0] ^ ve.Y[countY];
+        z[1] = x[1] ^ y[1] ^ ve1.Y[countY];
+        countY += 1;
+        return (true, z, randCount, countY);
+    }
+
+    function mpcMAJVerify(
+        uint32[2] memory a,
+        uint32[2] memory b,
+        uint32[2] memory c,
+        View memory ve,
+        View memory ve1,
+        bytes memory rand0,
+        bytes memory rand1,
+        uint randCount,
+        uint countY
+    ) internal pure returns (bool, uint32[2] memory, uint, uint) {
+        uint32[2] memory t0 = mpcXOR2(a, b);
+        uint32[2] memory t1 = mpcXOR2(a, c);
+        bool ok;
+        (ok, t0, randCount, countY) = mpcANDVerify(t0, t1, ve, ve1, rand0, rand1, randCount, countY);
+        if (!ok) return (false, t0, randCount, countY);
+        uint32[2] memory maj = mpcXOR2(t0, a);
+        return (true, maj, randCount, countY);
+    }
+
+    function mpcCHVerify(
+        uint32[2] memory e,
+        uint32[2] memory f,
+        uint32[2] memory g,
+        View memory ve,
+        View memory ve1,
+        bytes memory rand0,
+        bytes memory rand1,
+        uint randCount,
+        uint countY
+    ) internal pure returns (bool, uint32[2] memory, uint, uint) {
+        uint32[2] memory t0 = mpcXOR2(f, g);
+        bool ok;
+        (ok, t0, randCount, countY) = mpcANDVerify(e, t0, ve, ve1, rand0, rand1, randCount, countY);
+        if (!ok) return (false, t0, randCount, countY);
+        uint32[2] memory ch = mpcXOR2(t0, g);
+        return (true, ch, randCount, countY);
+    }
+
+    function pair(uint32 x) internal pure returns (uint32[2] memory p) {
+        p[0] = x;
+        p[1] = x;
+    }
+
+    function verify(A memory a, uint8 e, Z memory z) public pure returns (bool) {
+        if (computeH(z.Ke, z.Ve, z.Re) != a.H[e]) return false;
+        if (computeH(z.Ke1, z.Ve1, z.Re1) != a.H[(e + 1) % 3]) return false;
+
+        uint32[8] memory res = outputSHA256(z.Ve);
+        for (uint i = 0; i < 8; i++) {
+            if (a.Yp[e][i] != res[i]) return false;
+        }
+        res = outputSHA256(z.Ve1);
+        for (uint i = 0; i < 8; i++) {
+            if (a.Yp[(e + 1) % 3][i] != res[i]) return false;
+        }
+
+        bytes memory rand0 = getAllRandomness(z.Ke);
+        bytes memory rand1 = getAllRandomness(z.Ke1);
+        uint randCount = 0;
+        uint countY = 0;
+
+        uint32[2][64] memory w;
+        for (uint j = 0; j < 16; j++) {
+            w[j][0] = (uint32(z.Ve.X[j * 4]) << 24) |
+                (uint32(z.Ve.X[j * 4 + 1]) << 16) |
+                (uint32(z.Ve.X[j * 4 + 2]) << 8) |
+                uint32(z.Ve.X[j * 4 + 3]);
+            w[j][1] = (uint32(z.Ve1.X[j * 4]) << 24) |
+                (uint32(z.Ve1.X[j * 4 + 1]) << 16) |
+                (uint32(z.Ve1.X[j * 4 + 2]) << 8) |
+                uint32(z.Ve1.X[j * 4 + 3]);
+        }
+        uint32[2] memory s0;
+        uint32[2] memory s1;
+        uint32[2] memory t0;
+        uint32[2] memory t1;
+        bool ok;
+        for (uint j = 16; j < 64; j++) {
+            t0 = mpcRIGHTROTATE2(w[j - 15], 7);
+            t1 = mpcRIGHTROTATE2(w[j - 15], 18);
+            t0 = mpcXOR2(t0, t1);
+            t1 = mpcRIGHTSHIFT2(w[j - 15], 3);
+            s0 = mpcXOR2(t0, t1);
+
+            t0 = mpcRIGHTROTATE2(w[j - 2], 17);
+            t1 = mpcRIGHTROTATE2(w[j - 2], 19);
+            t0 = mpcXOR2(t0, t1);
+            t1 = mpcRIGHTSHIFT2(w[j - 2], 10);
+            s1 = mpcXOR2(t0, t1);
+
+            (ok, t1, randCount, countY) = mpcADDVerify(w[j - 16], s0, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, t1, randCount, countY) = mpcADDVerify(w[j - 7], t1, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, w[j], randCount, countY) = mpcADDVerify(t1, s1, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+        }
+
+        uint32[2] memory va = pair(H_INIT[0]);
+        uint32[2] memory vb = pair(H_INIT[1]);
+        uint32[2] memory vc = pair(H_INIT[2]);
+        uint32[2] memory vd = pair(H_INIT[3]);
+        uint32[2] memory ve2 = pair(H_INIT[4]);
+        uint32[2] memory vf = pair(H_INIT[5]);
+        uint32[2] memory vg = pair(H_INIT[6]);
+        uint32[2] memory vh = pair(H_INIT[7]);
+        uint32[2] memory temp1;
+        uint32[2] memory temp2;
+        uint32[2] memory maj;
+        for (uint i = 0; i < 64; i++) {
+            t0 = mpcRIGHTROTATE2(ve2, 6);
+            t1 = mpcRIGHTROTATE2(ve2, 11);
+            t0 = mpcXOR2(t0, t1);
+            t1 = mpcRIGHTROTATE2(ve2, 25);
+            s1 = mpcXOR2(t0, t1);
+
+            (ok, t0, randCount, countY) = mpcADDVerify(vh, s1, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, t1, randCount, countY) = mpcCHVerify(ve2, vf, vg, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, t1, randCount, countY) = mpcADDVerify(t0, t1, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, t1, randCount, countY) = mpcADDVerify(t1, pair(K[i]), z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, temp1, randCount, countY) = mpcADDVerify(t1, w[i], z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+
+            t0 = mpcRIGHTROTATE2(va, 2);
+            t1 = mpcRIGHTROTATE2(va, 13);
+            t0 = mpcXOR2(t0, t1);
+            t1 = mpcRIGHTROTATE2(va, 22);
+            s0 = mpcXOR2(t0, t1);
+
+            (ok, maj, randCount, countY) = mpcMAJVerify(va, vb, vc, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            (ok, temp2, randCount, countY) = mpcADDVerify(s0, maj, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+
+            vh = vg;
+            vg = vf;
+            vf = ve2;
+            (ok, ve2, randCount, countY) = mpcADDVerify(vd, temp1, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+            vd = vc;
+            vc = vb;
+            vb = va;
+            (ok, va, randCount, countY) = mpcADDVerify(temp1, temp2, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+            if (!ok) return false;
+        }
+
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[0]), va, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[1]), vb, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[2]), vc, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[3]), vd, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[4]), ve2, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[5]), vf, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[6]), vg, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+        (ok, temp1, randCount, countY) = mpcADDVerify(pair(H_INIT[7]), vh, z.Ve, z.Ve1, rand0, rand1, randCount, countY);
+        if (!ok) return false;
+
+        return true;
+    }
+}
+


### PR DESCRIPTION
## Summary
- scaffold Go module for ZKBoo reimplementation
- define core constants, data structures, and randomness generation
- port SHA-1 prover to Go using the shared view structure
- add SHA-1 verifier that replays MPC operations
- port SHA-256 prover and verifier with shared randomness helpers
- add Solidity SHA-256 verifier contract

## Testing
- `cd go && go build ./...`
- attempted `apt-get update` and `npm install -g solc`, but both returned 403 errors, so the Solidity contract could not be compiled


------
https://chatgpt.com/codex/tasks/task_e_688b92bf9d38832d8cf3f04e60440f05